### PR TITLE
Node v6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,6 @@
 {
   "plugins": [
     "transform-strict-mode",
-    "transform-es2015-spread",
-    "transform-object-rest-spread",
     "transform-class-properties"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "plugins": [
     "transform-strict-mode",
+    "transform-es2015-spread",
+    "transform-object-rest-spread",
     "transform-class-properties"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,7 @@
 {
   "plugins": [
-    "transform-es2015-spread",
-    "transform-es2015-destructuring",
     "transform-strict-mode",
-    "transform-es2015-parameters",
-    "transform-es2015-shorthand-properties",
+    "transform-es2015-spread",
     "transform-object-rest-spread",
     "transform-class-properties"
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,8 @@
   ],
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "no-param-reassign": [2, {"props": false}]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "airbnb/base",
+  "extends": "airbnb-base",
   "parser": "babel-eslint",
   "plugins": [
     "mocha"
@@ -8,6 +8,9 @@
     "mocha": true
   },
   "rules": {
-    "no-param-reassign": [2, {"props": false}]
+    "no-param-reassign": [2, {"props": false}],
+    "global-require": 0,
+    "no-underscore-dangle": 0,
+    'no-case-declarations': 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contains rabbitmq-based transport for establishing a net of loosely coupled micr
 calling interface.
 
 [![npm version](https://badge.fury.io/js/ms-amqp-transport.svg)](https://badge.fury.io/js/ms-amqp-transport)
-[![Build Status](https://semaphoreci.com/api/v1/projects/f51a48da-b026-4c59-a488-33a1feae4305/662691/shields_badge.svg)](https://semaphoreci.com/makeomatic/ms-amqp-transport)
+[![Build Status](https://semaphoreci.com/api/v1/makeomatic/ms-amqp-transport/branches/feat-node-6/shields_badge.svg)](https://semaphoreci.com/makeomatic/ms-amqp-transport)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
     "babel-cli": "^6.4.0",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
-    "babel-plugin-transform-es2015-destructuring": "^6.4.0",
-    "babel-plugin-transform-es2015-parameters": "^6.4.2",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
-    "babel-plugin-transform-es2015-spread": "^6.4.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-strict-mode": "^6.3.13",
     "babel-register": "^6.3.13",
@@ -37,7 +34,7 @@
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-mocha": "^2.2.0",
     "mocha": "^2.3.4",
-    "semantic-release": "^4.3.5"
+    "semantic-release": "^6.0.0"
   },
   "dependencies": {
     "amqp-coffee": "^0.1.27",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-cli": "^6.4.0",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-spread": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-strict-mode": "^6.3.13",
     "babel-register": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "description": "microservice utils based on amqp transport layer",
   "main": "./lib/index.js",
   "scripts": {
-    "compile": "./node_modules/.bin/babel -d ./lib ./src",
+    "compile": "babel -d ./lib ./src",
     "prepublish": "npm run compile",
-    "test": "./node_modules/.bin/mocha",
+    "lint": "eslint ./src",
+    "test": "npm run lint && mocha",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -20,7 +21,7 @@
   "homepage": "https://github.com/makeomatic/ms-amqp-transport#readme",
   "devDependencies": {
     "babel-cli": "^6.4.0",
-    "babel-eslint": "^5.0.0-beta6",
+    "babel-eslint": "^6.0.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-es2015-destructuring": "^6.4.0",
     "babel-plugin-transform-es2015-parameters": "^6.4.2",
@@ -31,19 +32,20 @@
     "babel-register": "^6.3.13",
     "chai": "^3.4.1",
     "cz-conventional-changelog": "^1.1.5",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "^3.1.0",
-    "eslint-plugin-mocha": "^1.1.0",
+    "eslint": "^2.9.0",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-mocha": "^2.2.0",
     "mocha": "^2.3.4",
     "semantic-release": "^4.3.5"
   },
   "dependencies": {
-    "amqp-coffee": "github:makeomatic/amqp-coffee#v0.1.27-rc0",
+    "amqp-coffee": "^0.1.27",
     "bluebird": "^3.1.1",
     "common-errors": "^0.5.3",
     "eventemitter3": "^1.1.1",
     "json-stringify-safe": "^5.0.1",
-    "ms-validation": "^1.0.1",
+    "ms-validation": "^2.0.0",
     "node-uuid": "^1.4.7"
   },
   "release": {

--- a/src/amqp.js
+++ b/src/amqp.js
@@ -606,7 +606,7 @@ class AMQPTransport extends EventEmitter {
 
       return promise
         .return(this)
-        .call('_createMessageHandler', routing, message, options, errorMessage, publishMessage)
+        .call('_createMessageHandler', routing, message, options, publishMessage)
         .tap(() => {
           debug('private queue created in %s', latency(time));
         });
@@ -617,7 +617,7 @@ class AMQPTransport extends EventEmitter {
       // set timer
       const correlationId = options.correlationId || uuid.v4();
       const timeout = options.timeout || this._config.timeout;
-      const timer = this._initTimeout(reject, timeout, correlationId, errorMessage);
+      const timer = this._initTimeout(reject, timeout, correlationId, routing);
 
       // push into queue
       this._replyQueue.set(correlationId, { resolve, reject, timer, time });

--- a/src/amqp.js
+++ b/src/amqp.js
@@ -7,7 +7,7 @@ const os = require('os');
 const ld = require('lodash');
 const pkg = require('../package.json');
 const path = require('path');
-const { format: fmt } = require('util');
+const fmt = require('util').format;
 const debug = require('debug')('ms-amqp-transport');
 const latency = time => {
   const execTime = process.hrtime(time);
@@ -542,16 +542,17 @@ class AMQPTransport extends EventEmitter {
    * @return {Promise}
    */
   _awaitPrivateQueue() {
+    /* eslint-disable prefer-const */
     return new Promise((resolve, reject) => {
       let done;
       let error;
 
-      done = function onReady() { // eslint-disable-line prefer-const
+      done = function onReady() {
         this.removeAllListeners('error', error);
         resolve(this);
       };
 
-      error = function onError(err) { // eslint-disable-line prefer-const
+      error = function onError(err) {
         this.removeListener('private-queue-ready', done);
         reject(err);
       };
@@ -559,6 +560,7 @@ class AMQPTransport extends EventEmitter {
       this.once('private-queue-ready', done);
       this.once('error', error);
     });
+    /* eslint-enable prefer-const */
   }
 
   _initTimeout(reject, timeout, correlationId, errorMessage) {

--- a/src/amqp.js
+++ b/src/amqp.js
@@ -76,7 +76,6 @@ class AMQPTransport extends EventEmitter {
   /**
    * Instantiate AMQP Transport
    * @param  {Object} opts, defaults to {}
-   *   - @param {}
    */
   constructor(opts = {}) {
     super();
@@ -713,8 +712,6 @@ class AMQPTransport extends EventEmitter {
     const { correlationId } = headers;
     const future = this._replyQueue.get(correlationId);
 
-    debug('response returned in %s', latency(future.time));
-
     if (!future) {
       this.log(
         'no recipient for the message %s and id %s',
@@ -732,6 +729,8 @@ class AMQPTransport extends EventEmitter {
       // mute
       return null;
     }
+
+    debug('response returned in %s', latency(future.time));
 
     clearTimeout(future.timer);
     this._replyQueue.delete(correlationId);

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -1,7 +1,7 @@
 const Errors = require('common-errors');
 const MSError = Errors.helpers.generateClass('MSError', {
   globalize: false,
-  args: [ 'message' ],
+  args: ['message'],
 });
 
 /**
@@ -17,9 +17,7 @@ function serializeError(error) {
 
   serialized.data = Object
     .getOwnPropertyNames(error)
-    .map(function transferErrorContext(key) {
-      return { key, value: error[key] };
-    });
+    .map(key => ({ key, value: error[key] }));
 
   return serialized;
 }
@@ -31,7 +29,7 @@ function serializeError(error) {
  */
 function deserializeError(error) {
   const deserialized = new MSError();
-  error.forEach(function transferSerializedErrorContext(data) {
+  error.forEach(data => {
     deserialized[data.key] = data.value;
   });
 
@@ -54,7 +52,7 @@ function jsonDeserializer(key, value) {
       if (type === 'ms-error') {
         return deserializeError(data);
       } else if (type === 'buffer') {
-        return new Buffer(data);
+        return Buffer.from(data);
       }
     }
   }

--- a/test/amqp-transport.js
+++ b/test/amqp-transport.js
@@ -3,6 +3,10 @@ const expect = chai.expect;
 const Errors = require('common-errors');
 const Promise = require('bluebird');
 const ld = require('lodash');
+const latency = time => {
+  const execTime = process.hrtime(time);
+  return execTime[0] * 1000 + (+(execTime[1] / 1000000).toFixed(3));
+};
 
 describe('AMQPTransport', function AMQPTransportTestSuite() {
   // require module
@@ -69,7 +73,7 @@ describe('AMQPTransport', function AMQPTransportTestSuite() {
 
     return AMQPTransport
       .connect(opts, function listener(message, headers, actions, callback) {
-        callback(null, message + '-response');
+        callback(null, { resp: message + '-response', time: process.hrtime() });
       })
       .then(amqp => {
         expect(amqp._amqp.state).to.be.eq('open');
@@ -78,8 +82,29 @@ describe('AMQPTransport', function AMQPTransportTestSuite() {
   });
 
   it('is able to publish to route consumer', () => {
+    const sending = process.hrtime();
     return this.amqp.publishAndWait('test.default', 'test-message').then((response) => {
-      expect(response).to.be.eq('test-message-response');
+      expect(response.resp).to.be.eq('test-message-response');
+      console.log(response.time);
+      console.log('response sent and received after %s, total time %s', latency(response.time), latency(sending));
+    });
+  });
+
+  it('is able to publish to route consumer:2', () => {
+    const sending = process.hrtime();
+    return this.amqp.publishAndWait('test.default', 'test-message').then((response) => {
+      expect(response.resp).to.be.eq('test-message-response');
+      console.log(response.time);
+      console.log('response sent and received after %s, total time %s', latency(response.time), latency(sending));
+    });
+  });
+
+  it('is able to publish to route consumer:2', () => {
+    const sending = process.hrtime();
+    return this.amqp.publishAndWait('test.default', 'test-message').then((response) => {
+      expect(response.resp).to.be.eq('test-message-response');
+      console.log(response.time);
+      console.log('response sent and received after %s, total time %s', latency(response.time), latency(sending));
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: use `Buffer.from` instead of deprecated `new Buffer`, remove implemented transpilers