### PR TITLE
feat: release v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ calling interface.
 
 Heavily relies on `dropbox/amqp-coffee` lib for establishing communication to rabbitmq.
 
+## Notice, Upgrade from 3.x to 4.x
+
+* ms-validation became a peer dependency, >= 3.x.x
+* node must be of version >= 6.2.0
+* npm must be >= 3.x.x
+
+Rest is exactly the same as before
+
 ## Usage
 
 ```js


### PR DESCRIPTION
BREAKING CHANGE: removed some babel transforms, requires node > 6.2.x, npm > 3.x.x
Added ~1.x.x peerDependency of common-errors to make sure it's consistent across the project